### PR TITLE
Various fixes for compatibility with Yocto Styhead.

### DIFF
--- a/recipes-core/ant/ant-native_1.8.1.bb
+++ b/recipes-core/ant/ant-native_1.8.1.bb
@@ -54,12 +54,12 @@ do_compile() {
 
   oe_makeclasspath cp -s ecj-bootstrap jsch bsf xalan2 xercesImpl resolver gnumail gnujaf bcel regexp log4j1.2 antlr oro junit jdepend commons-net commons-logging
   cp=${STAGING_DATADIR_JAVA_NATIVE}/ant.jar:${STAGING_DATADIR}/classpath/tools.zip:$cp
-  sed -i -e"s|@JAR_FILE@|$cp|" ${WORKDIR}/ant
+  sed -i -e"s|@JAR_FILE@|$cp|" ${UNPACKDIR}/ant
 }
 
 do_install:append() {
 	install -d ${D}${bindir}
-	install -m 0755 ${WORKDIR}/ant ${D}${bindir}
+	install -m 0755 ${UNPACKDIR}/ant ${D}${bindir}
 }
 
 SRC_URI[sha256sum] = "4f39057af228663c3cfb6dcfbee603a071a7e3cf48c95c30869ed81c5fcf21c8"

--- a/recipes-core/antlr/antlr_2.7.7.bb
+++ b/recipes-core/antlr/antlr_2.7.7.bb
@@ -10,7 +10,7 @@ SRC_URI:append:class-native = " file://runantlr"
 inherit java-library
 
 do_configure:class-native() {
-    sed -i -e"s|@JAR_FILE@|${STAGING_DATADIR_JAVA_NATIVE}/antlr.jar|" ${WORKDIR}/runantlr
+    sed -i -e"s|@JAR_FILE@|${STAGING_DATADIR_JAVA_NATIVE}/antlr.jar|" ${UNPACKDIR}/runantlr
 }
 
 do_compile() {
@@ -23,7 +23,7 @@ do_compile() {
 
 do_install:class-native() {
     install -d ${D}${bindir}
-    install -m 0755 ${WORKDIR}/runantlr ${D}${bindir}/
+    install -m 0755 ${UNPACKDIR}/runantlr ${D}${bindir}/
 }
 
 SRC_URI[sha256sum] = "853aeb021aef7586bda29e74a6b03006bcb565a755c86b66032d8ec31b67dbb9"

--- a/recipes-core/ca-certificates-java/ca-certificates-java_20180516.bb
+++ b/recipes-core/ca-certificates-java/ca-certificates-java_20180516.bb
@@ -67,7 +67,7 @@ do_install () {
 	oe_jarinstall ${JARFILENAME}
 
 	mkdir -p ${D}${sysconfdir}/ssl/certs/java
-	install -Dm0755 ${WORKDIR}/${BPN}.hook.in ${D}${sysconfdir}/ca-certificates/update.d/${BPN}-hook
+	install -Dm0755 ${UNPACKDIR}/${BPN}.hook.in ${D}${sysconfdir}/ca-certificates/update.d/${BPN}-hook
 	sed -e 's|@@datadir_java@@|${datadir_java}|' \
 	    -e 's|@@libdir_jvm@@|${libdir_jvm}|' \
 	    -e 's|@@JARFILENAME@@|${JARFILENAME}|' \

--- a/recipes-core/ca-certificates-java/ca-certificates-java_20180516.bb
+++ b/recipes-core/ca-certificates-java/ca-certificates-java_20180516.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Common CA certificates (JKS trustStore)"
 DESCRIPTION = "This package uses the hooks of the ca-certificates \
 package to update the cacerts JKS trustStore used for many java runtimes."
-LICENSE = "GPLv2+"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "\
 	file://debian/copyright;md5=ab0f6b6900f6564dc3e273dfa36fcc72 \
 	file://src/main/java/org/debian/security/InvalidKeystorePasswordException.java;endline=17;md5=f9150bf1ca3139a38ddb54f9e1c0eb9b \

--- a/recipes-core/cacao/files/cacao-0.98-initial.patch
+++ b/recipes-core/cacao/files/cacao-0.98-initial.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 Index: cacao-0.98/configure.ac
 ===================================================================
 --- cacao-0.98.orig/configure.ac	2007-12-19 22:07:55.000000000 +0100

--- a/recipes-core/cacao/files/disable_hw_exceptions.patch
+++ b/recipes-core/cacao/files/disable_hw_exceptions.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 Index: cacao-0.98/src/vm/exceptions.c
 ===================================================================
 --- cacao-0.98.orig/src/vm/exceptions.c	2007-06-05 09:41:07.000000000 +0200

--- a/recipes-core/classpath/classpath-0.93/autotools.patch
+++ b/recipes-core/classpath/classpath-0.93/autotools.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [dead project]
+
 Index: classpath-0.93/configure.ac
 ===================================================================
 --- classpath-0.93.orig/configure.ac	2006-12-08 20:22:50.000000000 +0100

--- a/recipes-core/classpath/classpath-0.93/miscompilation.patch
+++ b/recipes-core/classpath/classpath-0.93/miscompilation.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [dead project]
+
 Index: classpath-0.93/native/jni/java-io/java_io_VMFile.c
 ===================================================================
 --- classpath-0.93.orig/native/jni/java-io/java_io_VMFile.c	2006-09-23 07:17:45.000000000 +0200

--- a/recipes-core/classpath/classpath-0.99/autotools.patch
+++ b/recipes-core/classpath/classpath-0.99/autotools.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [dead project]
+
 Index: classpath-0.99/configure.ac
 ===================================================================
 --- classpath-0.99.orig/configure.ac	2012-03-08 19:03:15.000000000 +0100

--- a/recipes-core/classpath/classpath-0.99/ecj_java_dir.patch
+++ b/recipes-core/classpath/classpath-0.99/ecj_java_dir.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [dead project]
+
 Index: classpath-0.98/lib/gen-classlist.sh.in
 ===================================================================
 --- classpath-0.98.orig/lib/gen-classlist.sh.in	2010-06-24 21:18:02.776819217 +0200

--- a/recipes-core/classpath/classpath-0.99/freetype2.patch
+++ b/recipes-core/classpath/classpath-0.99/freetype2.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [dead project]
+
 Index: classpath-0.99/native/jni/gtk-peer/gnu_java_awt_peer_gtk_FreetypeGlyphVector.c
 ===================================================================
 --- classpath-0.99.orig/native/jni/gtk-peer/gnu_java_awt_peer_gtk_FreetypeGlyphVector.c	2014-02-10 12:01:26.826613065 +0100

--- a/recipes-core/classpath/classpath-0.99/miscompilation.patch
+++ b/recipes-core/classpath/classpath-0.99/miscompilation.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [dead project]
+
 Index: classpath-0.97.2/native/jni/java-io/java_io_VMFile.c
 ===================================================================
 --- classpath-0.97.2.orig/native/jni/java-io/java_io_VMFile.c	2008-10-10 15:24:54.000000000 +0200

--- a/recipes-core/classpath/classpath-0.99/sun-security-getproperty.patch
+++ b/recipes-core/classpath/classpath-0.99/sun-security-getproperty.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [dead project]
+
 Index: gnu/classpath/debug/Simple1LineFormatter.java
 ===================================================================
 --- gnu/classpath/debug/Simple1LineFormatter.java.orig	2006-07-11 18:03:59.000000000 +0200

--- a/recipes-core/classpath/classpath-0.99/toolwrapper-exithook.patch
+++ b/recipes-core/classpath/classpath-0.99/toolwrapper-exithook.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [dead project]
+
 Index: classpath-0.97.2/tools/toolwrapper.c
 ===================================================================
 --- classpath-0.97.2.orig/tools/toolwrapper.c	2006-12-13 18:56:44.000000000 +0100

--- a/recipes-core/classpath/classpath-0.99/use_libdir.patch
+++ b/recipes-core/classpath/classpath-0.99/use_libdir.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [dead project]
+
 on some arches we use lib64 for libdir so hardcoding to lib
 is not gonna work always
 

--- a/recipes-core/classpathx/gnujaf-1.1.1/datadir_java.patch
+++ b/recipes-core/classpathx/gnujaf-1.1.1/datadir_java.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 Index: activation-1.1.1/Makefile.am
 ===================================================================
 --- activation-1.1.1.orig/Makefile.am	2008-03-01 10:30:06.000000000 +0100

--- a/recipes-core/classpathx/gnumail-1.1.2/datadir_java.patch
+++ b/recipes-core/classpathx/gnumail-1.1.2/datadir_java.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 Index: mail-1.1.2/Makefile.am
 ===================================================================
 --- mail-1.1.2.orig/Makefile.am	2008-03-01 11:13:36.000000000 +0100

--- a/recipes-core/classpathx/inetlib-1.1.1/datadir_java.patch
+++ b/recipes-core/classpathx/inetlib-1.1.1/datadir_java.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 Index: inetlib-1.1.1/Makefile.am
 ===================================================================
 --- inetlib-1.1.1.orig/Makefile.am	2008-03-01 10:49:49.000000000 +0100

--- a/recipes-core/classpathx/inetlib-1.1.1/inetlib-missing-dependency-for-util_classes.patch
+++ b/recipes-core/classpathx/inetlib-1.1.1/inetlib-missing-dependency-for-util_classes.patch
@@ -7,6 +7,7 @@ Fix a dependency for intermittent build failures, e.g.:
 1. ERROR in source/gnu/inet/util/SaslCallbackHandler.java (at line 43)
         import javax.security.auth.callback.Callback;
                ^^^^^^^^^^^^^^
+Upstream-Status: Inappropriate [dead project]
 
 Signed-off-by: Paul Barrette <paul.barrette@windriver.com>
 ---

--- a/recipes-core/cup/cup_0.10k.bb
+++ b/recipes-core/cup/cup_0.10k.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Lexical analyzer generator for Java"
 AUTHOR = "Elliot Berk, A. Appel, C. Scott Ananian"
 LICENSE = "CUP"
-LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE;md5=2c9db91c00f38e52cfc8e67bafaa7c33"
+LIC_FILES_CHKSUM = "file://${UNPACKDIR}/LICENSE;md5=2c9db91c00f38e52cfc8e67bafaa7c33"
 
 
 RDEPENDS:${PN} = "java2-runtime"
@@ -21,7 +21,7 @@ do_configure() {
 		-e "s|OE_STAGING_BINDIR|${bindir}|" \
 		-e "s|OE_STAGING_DATADIR_JAVA|${data_java}|" \
 		-e "s|OE_CUP_JAR|${BP}.jar|" \
-		${WORKDIR}/cup
+		${UNPACKDIR}/cup
 }
 
 do_compile() {
@@ -34,7 +34,7 @@ do_compile() {
 
 do_install:append() {
 	install -d ${D}${bindir}
-	install -m 0755 ${WORKDIR}/cup ${D}${bindir}
+	install -m 0755 ${UNPACKDIR}/cup ${D}${bindir}
 }
 
 PACKAGES = "${PN}"

--- a/recipes-core/ecj/ecj-bootstrap-native.bb
+++ b/recipes-core/ecj/ecj-bootstrap-native.bb
@@ -18,7 +18,8 @@ PROVIDES = "virtual/javac-native"
 
 SRC_URI = "file://ecj.in"
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 
 JAR = "ecj-bootstrap.jar"
 

--- a/recipes-core/ecj/ecj-initial-native.bb
+++ b/recipes-core/ecj/ecj-initial-native.bb
@@ -12,7 +12,8 @@ DEPENDS = "libecj-bootstrap-native"
 
 SRC_URI = "file://ecj-initial.in"
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 
 inherit native
 

--- a/recipes-core/ecj/libecj-bootstrap.inc
+++ b/recipes-core/ecj/libecj-bootstrap.inc
@@ -11,7 +11,8 @@ INC_PR = "r5"
 
 inherit java native
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 
 JAR = "ecj-bootstrap-${PV}.jar"
 

--- a/recipes-core/fastjar/fastjar/jartool.patch
+++ b/recipes-core/fastjar/fastjar/jartool.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [dead project]
+
 Index: fastjar-0.98/jartool.c
 ===================================================================
 --- fastjar-0.98.orig/jartool.c	2009-09-07 00:10:47.000000000 +0200

--- a/recipes-core/icedtea/icedtea7-native.inc
+++ b/recipes-core/icedtea/icedtea7-native.inc
@@ -105,7 +105,7 @@ do_configure:prepend() {
 
 	# Automatically copy everything that starts with "icedtea" and ends with
 	# ".patch" into the patches directory.
-	find ${WORKDIR} -maxdepth 1 -name "icedtea*.patch" -exec cp {} ${S}/patches \;
+	find ${UNPACKDIR} -maxdepth 1 -name "icedtea*.patch" -exec cp {} ${S}/patches \;
 
 	# Prepare JDK-like directory with Classpath' files which we can treat as a
 	# SYSTEM_GCJ_DIR afterwards.
@@ -154,9 +154,9 @@ do_configure:append() {
 	${POST_CONFIGURE_CLEAN_X11}
 	oe_runmake patch-boot
 
-	patch -p1 < ${WORKDIR}/jaxws_fix_NullPointerException.patch
-	patch -p1 < ${WORKDIR}/sigsegv.patch
-	patch -p1 < ${WORKDIR}/vframeArray_Fix_sigsegv.patch
+	patch -p1 < ${UNPACKDIR}/jaxws_fix_NullPointerException.patch
+	patch -p1 < ${UNPACKDIR}/sigsegv.patch
+	patch -p1 < ${UNPACKDIR}/vframeArray_Fix_sigsegv.patch
 }
 
 EXTRA_OEMAKE = ' \

--- a/recipes-core/icedtea/openjdk-7-03b147/allow-headless-build.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/allow-headless-build.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 --- acinclude.m4.orig	2015-08-18 11:58:23.000000000 +0200
 +++ acinclude.m4	2015-08-18 11:58:30.000000000 +0200
 @@ -2178,3 +2178,37 @@

--- a/recipes-core/icedtea/openjdk-7-03b147/build-hacks-native.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/build-hacks-native.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 Index: icedtea-2.1/Makefile.am
 ===================================================================
 --- icedtea-2.1.orig/Makefile.am

--- a/recipes-core/icedtea/openjdk-7-03b147/disable-library-checks.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/disable-library-checks.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 Index: icedtea-2.1.3/configure.ac
 ===================================================================
 --- icedtea-2.1.3.orig/configure.ac	2012-10-17 10:18:59.262849964 +0200

--- a/recipes-core/icedtea/openjdk-7-03b147/fix-checksums.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/fix-checksums.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 --- icedtea-2.1.3/Makefile.am	2016-10-18 15:31:45.451073805 +0200
 +++ icedtea-2.1.3/Makefile.am	2016-10-18 15:42:14.651066400 +0200
 @@ -12,13 +12,13 @@

--- a/recipes-core/icedtea/openjdk-7-03b147/icedtea-change-to-gdb-debug-format.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/icedtea-change-to-gdb-debug-format.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 --- openjdk/hotspot/make/linux/makefiles/gcc.make	2015-04-02 08:02:31.301728214 +0200
 +++ openjdk/hotspot/make/linux/makefiles/gcc.make.new	2015-04-02 08:19:55.502171268 +0200
 @@ -233,7 +233,7 @@

--- a/recipes-core/icedtea/openjdk-7-03b147/icedtea-corba-parallel-make.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/icedtea-corba-parallel-make.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 diff --git openjdk/corba/make/Makefile openjdk/corba/make/Makefile
 index aef5c1b..62e2216 100644
 --- openjdk/corba/make/Makefile

--- a/recipes-core/icedtea/openjdk-7-03b147/icedtea-disable-sun.applet-for-tools-in-headless.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/icedtea-disable-sun.applet-for-tools-in-headless.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 --- openjdk/jdk/make/common/Release.gmk.orig	2015-08-20 10:08:34.631526528 +0200
 +++ openjdk/jdk/make/common/Release.gmk	2015-08-20 10:10:13.823526901 +0200
 @@ -340,7 +340,6 @@

--- a/recipes-core/icedtea/openjdk-7-03b147/icedtea-disable-x11-in-headless.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/icedtea-disable-x11-in-headless.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 --- openjdk/jdk/make/sun/awt/FILES_c_unix.gmk.orig	2015-08-19 11:53:47.209867982 +0200
 +++ openjdk/jdk/make/sun/awt/FILES_c_unix.gmk	2015-08-19 11:57:48.677868529 +0200
 @@ -207,12 +207,6 @@

--- a/recipes-core/icedtea/openjdk-7-03b147/icedtea-ecj-disable-compilation.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/icedtea-ecj-disable-compilation.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 diff --git openjdk/jdk/make/common/Sanity.gmk openjdk/jdk/make/common/Sanity.gmk
 index 27fe5bd..97ad549 100644
 --- openjdk/jdk/make/common/Sanity.gmk

--- a/recipes-core/icedtea/openjdk-7-03b147/icedtea-flags.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/icedtea-flags.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 diff --git openjdk/hotspot/agent/src/os/linux/Makefile openjdk/hotspot/agent/src/os/linux/Makefile
 index 25d43ae..ac3de8b 100644
 --- openjdk/hotspot/agent/src/os/linux/Makefile

--- a/recipes-core/icedtea/openjdk-7-03b147/icedtea-hotspot-fix-prefix_relocInfo-declaration.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/icedtea-hotspot-fix-prefix_relocInfo-declaration.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 --- openjdk/hotspot/src/share/vm/code/relocInfo.hpp
 +++ openjdk/hotspot/src/share/vm/code/relocInfo.hpp
 @@ -371,7 +371,7 @@

--- a/recipes-core/icedtea/openjdk-7-03b147/icedtea-hotspot-handle-gcc7-format-overflow.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/icedtea-hotspot-handle-gcc7-format-overflow.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Backport
+
 # HG changeset patch
 # User Andreas Obergschwandtner <andreas.obergschwandtner@skidata.com>
 # Date 1534928526 -7200

--- a/recipes-core/icedtea/openjdk-7-03b147/icedtea-hotspot-make-arch-sane-for-x86.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/icedtea-hotspot-make-arch-sane-for-x86.patch
@@ -3,6 +3,8 @@ From: Henning Heinold <heinold@inf.fu-berlin.de>
 Date: Wed, 14 Mar 2012 22:15:47 +0100
 Subject: [PATCH] foo
 
+Upstream-Status: Backport
+
 ---
  hotspot/agent/make/saenv.sh                  |    4 +-
  hotspot/make/defs.make                       |    4 +-

--- a/recipes-core/icedtea/openjdk-7-03b147/icedtea-jdk-fix-xattr-include.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/icedtea-jdk-fix-xattr-include.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 --- openjdk/jdk/src/solaris/native/sun/nio/fs/LinuxNativeDispatcher.c
 +++ openjdk/jdk/src/solaris/native/sun/nio/fs/LinuxNativeDispatcher.c
 @@ -37,7 +37,7 @@

--- a/recipes-core/icedtea/openjdk-7-03b147/icedtea-jdk-replace-sys-sysctl.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/icedtea-jdk-replace-sys-sysctl.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 --- openjdk/jdk/src/solaris/native/java/net/PlainDatagramSocketImpl.c
 +++ openjdk/jdk/src/solaris/native/java/net/PlainDatagramSocketImpl.c
 @@ -35,7 +35,7 @@

--- a/recipes-core/icedtea/openjdk-7-03b147/icedtea-jdk-sane-x86-arch.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/icedtea-jdk-sane-x86-arch.patch
@@ -3,6 +3,8 @@ From: Henning Heinold <heinold@inf.fu-berlin.de>
 Date: Wed, 14 Mar 2012 22:34:51 +0100
 Subject: [PATCH] real patch
 
+Upstream-Status: Backport
+
 ---
  jdk/make/common/shared/Compiler-gcc.gmk            |    4 +-
  jdk/make/common/shared/Platform.gmk                |   18 ++++------

--- a/recipes-core/icedtea/openjdk-7-03b147/icedtea-m4-fix-xattr-include-path.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/icedtea-m4-fix-xattr-include-path.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 --- a/acinclude.m4
 +++ b/acinclude.m4
 @@ -2102,7 +2102,7 @@

--- a/recipes-core/icedtea/openjdk-7-03b147/icedtea-openjdk-remove-currency-data-generation-expi.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/icedtea-openjdk-remove-currency-data-generation-expi.patch
@@ -4,6 +4,8 @@ Date: Wed, 31 Dec 2014 16:07:32 +0100
 Subject: [PATCH] icedtea: openjdk: remove currency data generation expiration
  date
 
+Upstream-Status: Backport
+
 Signed-off-by: Alex Gonzalez <alex.gonzalez@digi.com>
 ---
  .../src/build/tools/generatecurrencydata/GenerateCurrencyData.java     | 3 ---

--- a/recipes-core/icedtea/openjdk-7-03b147/icedtea-sane-x86-arch-name.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/icedtea-sane-x86-arch-name.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Backport
+
 Index: icedtea-2.1/acinclude.m4
 ===================================================================
 --- icedtea-2.1.orig/acinclude.m4

--- a/recipes-core/icedtea/openjdk-7-03b147/icedtea-unbreak-float.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/icedtea-unbreak-float.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Backport
+
 --- openjdk/jdk/src/share/native/java/lang/fdlibm/include/fdlibm.h
 +++ openjdk/jdk/src/share/native/java/lang/fdlibm/include/fdlibm.h
 @@ -26,13 +26,11 @@

--- a/recipes-core/icedtea/openjdk-7-03b147/sigsegv.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/sigsegv.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Backport
+
 diff --git a/openjdk-boot/hotspot/src/share/vm/runtime/thread.cpp b/openjdk-boot/hotspot/src/share/vm/runtime/thread.cpp
 index 8b7059c8389f..67e9e7bd4bce 100644
 --- a/openjdk-boot/hotspot/src/share/vm/runtime/thread.cpp

--- a/recipes-core/icedtea/openjdk-7-03b147/timezoneszip.patch
+++ b/recipes-core/icedtea/openjdk-7-03b147/timezoneszip.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Backport
+
 diff --git a/Makefile.am b/Makefile.am
 index 5eaff4c40aac..a4f0f63f3e43 100644
 --- a/Makefile.am

--- a/recipes-core/jakarta-libs/avalon-framework-api_4.3.bb
+++ b/recipes-core/jakarta-libs/avalon-framework-api_4.3.bb
@@ -15,7 +15,7 @@ do_compile() {
   mkdir -p build
 
 	#	Allow reaching method definitions from logkit (stupid cyclic dependency).
-	srcpath=src/java:${WORKDIR}/logkit-1.2.2-dev/src/java
+	srcpath=src/java:${UNPACKDIR}/logkit-1.2.2-dev/src/java
 
   javac -encoding ISO-8859-1 -sourcepath $srcpath -d build `find src/java -name "*.java"`
 

--- a/recipes-core/jamvm/jamvm-1.4.5/jamvm-initial.patch
+++ b/recipes-core/jamvm/jamvm-1.4.5/jamvm-initial.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 Index: jamvm-1.4.5/configure.ac
 ===================================================================
 --- jamvm-1.4.5.orig/configure.ac

--- a/recipes-core/jamvm/jamvm-1.4.5/libffi.patch
+++ b/recipes-core/jamvm/jamvm-1.4.5/libffi.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 Index: jamvm-1.4.5/configure.ac
 ===================================================================
 --- jamvm-1.4.5.orig/configure.ac	2007-02-05 04:18:05.000000000 +0100

--- a/recipes-core/jamvm/jamvm.inc
+++ b/recipes-core/jamvm/jamvm.inc
@@ -25,7 +25,7 @@ ARM_INSTRUCTION_SET = "arm"
 do_configure:append:class-native() {
 	sed -i -e"s|STAGING_LIBDIR_NATIVE|${STAGING_LIBDIR_NATIVE}|g" \
 		-e "s|STAGING_DATADIR_NATIVE|${STAGING_DATADIR_NATIVE}|g" \
-	${WORKDIR}/java
+	${UNPACKDIR}/java
 }
 
 
@@ -44,7 +44,7 @@ EXTRA_OEMAKE:class-native = "JAVAC=${STAGING_BINDIR_NATIVE}/ecj-initial \
 
 do_install:append:class-native() {
 	install -d ${D}${bindir}
-	install -m 0755 ${WORKDIR}/java ${D}${bindir}/java
+	install -m 0755 ${UNPACKDIR}/java ${D}${bindir}/java
 
 }
 

--- a/recipes-core/jamvm/jamvm/jamvm-jni_h-noinst.patch
+++ b/recipes-core/jamvm/jamvm/jamvm-jni_h-noinst.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 From a0169a5569a0373558bd99143a02ba3ebe80b81b Mon Sep 17 00:00:00 2001
 From: Henning Heinold <heinold@inf.fu-berlin.de>
 Date: Sat, 12 Nov 2011 20:58:34 +0100

--- a/recipes-core/jamvm/jamvm/jamvm-minmax-heap.patch
+++ b/recipes-core/jamvm/jamvm/jamvm-minmax-heap.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 From 2409bdf5de64f1a6f2d8d3c738b06d394b47c198 Mon Sep 17 00:00:00 2001
 From: Jan Luebbe <jlu@pengutronix.de>
 Date: Tue, 15 May 2012 09:56:31 +0000

--- a/recipes-core/jamvm/jamvm/libffi.patch
+++ b/recipes-core/jamvm/jamvm/libffi.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 From fcd374ce67c0385ca94b09dfc1b1ddf13c3f631a Mon Sep 17 00:00:00 2001
 From: Henning Heinold <heinold@inf.fu-berlin.de>
 Date: Sat, 12 Nov 2011 20:58:34 +0100

--- a/recipes-core/jikes/jikes-initial-native.bb
+++ b/recipes-core/jikes/jikes-initial-native.bb
@@ -3,7 +3,8 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 DEPENDS = "jikes-native classpath-initial-native"
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 
 inherit native
 

--- a/recipes-core/jlex/jlex_1.2.6.bb
+++ b/recipes-core/jlex/jlex_1.2.6.bb
@@ -16,14 +16,15 @@ SRC_URI = "http://www.cs.princeton.edu/~appel/modern/java/JLex/Archive/${PV}/Mai
            file://jlex \
           "
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 
 do_configure() {
   sed -i \
     -e "s|OE_STAGING_BINDIR|${bindir}|" \
     -e "s|OE_STAGING_DATADIR_JAVA|${datadir_java}|" \
     -e "s|OE_JLEX_JAR|${BP}.jar|" \
-    ${WORKDIR}/jlex
+    ${UNPACKDIR}/jlex
 }
 
 do_compile() {

--- a/recipes-core/junit/junit4_4.3.1.bb
+++ b/recipes-core/junit/junit4_4.3.1.bb
@@ -6,7 +6,8 @@ HOMEPAGE = "http://www.junit.org"
 
 SRC_URI = "http://downloads.sourceforge.net/junit/junit-${PV}-src.jar"
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 
 inherit java-library
 

--- a/recipes-core/libmatthew/files/Makefile-0.7.patch
+++ b/recipes-core/libmatthew/files/Makefile-0.7.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto-specific fixes]
+
 Index: libmatthew-java-0.7/Makefile
 ===================================================================
 --- libmatthew-java-0.7.orig/Makefile	2008-05-27 13:17:47.000000000 +0800

--- a/recipes-core/openjdk/openjdk-7-common.inc
+++ b/recipes-core/openjdk/openjdk-7-common.inc
@@ -141,8 +141,8 @@ EXTRA_OECONF += " \
 do_configure:prepend() {
     # Automatically copy everything that starts with "icedtea" (or "cacao") and ends with
     # ".patch" into the patches directory.
-    find ${WORKDIR} -maxdepth 1 -name "icedtea*.patch" -exec cp {} ${S}/patches \;
-    find ${WORKDIR} -maxdepth 1 -name "cacao*.patch" -exec cp {} ${S}/patches \;
+    find ${UNPACKDIR} -maxdepth 1 -name "icedtea*.patch" -exec cp {} ${S}/patches \;
+    find ${UNPACKDIR} -maxdepth 1 -name "cacao*.patch" -exec cp {} ${S}/patches \;
 }
 
 do_configure:append() {
@@ -199,7 +199,7 @@ do_install() {
         ln -s ${JDK_HOME}/jre/bin/$bf ${D}${JDK_HOME}/bin/$bf
     done
 
-    install -m644 ${WORKDIR}/jvm.cfg  ${D}${JDK_HOME}/jre/lib/${JDK_ARCH}/
+    install -m644 ${UNPACKDIR}/jvm.cfg  ${D}${JDK_HOME}/jre/lib/${JDK_ARCH}/
     # workaround for shared libarary searching
     ln -sf ${JDK_HOME}/jre/lib/${JDK_ARCH}/server/libjvm.so ${D}${JDK_HOME}/jre/lib/${JDK_ARCH}/
 }

--- a/recipes-core/openjdk/openjdk-8-common.inc
+++ b/recipes-core/openjdk/openjdk-8-common.inc
@@ -34,13 +34,13 @@ do_configure:prepend () {
 do_unpack_extract_submodules () {
     cd "${S}"
     # tar --transform
-    tar xjf ${WORKDIR}/${CORBA_FILE_LOCAL} --transform "s,-${CORBA_CHANGESET},,g"
-    tar xjf ${WORKDIR}/${HOTSPOT_FILE_LOCAL} --transform "s,-${HOTSPOT_CHANGESET},,g"
-    tar xjf ${WORKDIR}/${JAXP_FILE_LOCAL} --transform "s,-${JAXP_CHANGESET},,g"
-    tar xjf ${WORKDIR}/${JAXWS_FILE_LOCAL} --transform "s,-${JAXWS_CHANGESET},,g"
-    tar xjf ${WORKDIR}/${JDK_FILE_LOCAL} --transform "s,-${JDK_CHANGESET},,g"
-    tar xjf ${WORKDIR}/${LANGTOOLS_FILE_LOCAL} --transform "s,-${LANGTOOLS_CHANGESET},,g"
-    tar xjf ${WORKDIR}/${NASHORN_FILE_LOCAL} --transform "s,-${NASHORN_CHANGESET},,g"
+    tar xjf ${UNPACKDIR}/${CORBA_FILE_LOCAL} --transform "s,-${CORBA_CHANGESET},,g"
+    tar xjf ${UNPACKDIR}/${HOTSPOT_FILE_LOCAL} --transform "s,-${HOTSPOT_CHANGESET},,g"
+    tar xjf ${UNPACKDIR}/${JAXP_FILE_LOCAL} --transform "s,-${JAXP_CHANGESET},,g"
+    tar xjf ${UNPACKDIR}/${JAXWS_FILE_LOCAL} --transform "s,-${JAXWS_CHANGESET},,g"
+    tar xjf ${UNPACKDIR}/${JDK_FILE_LOCAL} --transform "s,-${JDK_CHANGESET},,g"
+    tar xjf ${UNPACKDIR}/${LANGTOOLS_FILE_LOCAL} --transform "s,-${LANGTOOLS_CHANGESET},,g"
+    tar xjf ${UNPACKDIR}/${NASHORN_FILE_LOCAL} --transform "s,-${NASHORN_CHANGESET},,g"
 }
 
 do_patch:prepend() {

--- a/recipes-core/openjdk/openjdk-8-common.inc
+++ b/recipes-core/openjdk/openjdk-8-common.inc
@@ -185,8 +185,9 @@ EXTRA_OECONF:append = "\
 # Since v6, GCC sets the default C++ standard to C++14 and introduces
 # dead store elimination by default.
 # Since v10, GCC defaults to -fno-common.
+# Since v14, some warnings became errors to alert the programmer about ugly code
 # OpenJDK 8 is not ready for either of these changes.
-GLOBAL_FLAGS = "-fno-lifetime-dse -fno-delete-null-pointer-checks -fcommon"
+GLOBAL_FLAGS = "-fno-lifetime-dse -fno-delete-null-pointer-checks -fcommon -Wno-error=implicit-function-declaration -Wno-error=int-conversion -Wno-error=incompatible-pointer-types"
 
 # flags for -native, and for bits that need a host-tool during -cross
 BUILD_CFLAGS:append = " ${GLOBAL_FLAGS}"

--- a/recipes-core/openjdk/openjdk-8_272.bb
+++ b/recipes-core/openjdk/openjdk-8_272.bb
@@ -10,7 +10,7 @@ do_install() {
     mkdir -p ${D}${JDK_HOME}
     cp -rp ${B}/images/j2sdk-image/* ${D}${JDK_HOME}
     chown -R root:root ${D}${JDK_HOME}
-    install -m644 ${WORKDIR}/jvm.cfg  ${D}${JDK_HOME}/jre/lib/${JDK_ARCH}/
+    install -m644 ${UNPACKDIR}/jvm.cfg  ${D}${JDK_HOME}/jre/lib/${JDK_ARCH}/
     find ${D}${JDK_HOME} -name "*.debuginfo" -exec rm {} \;
 }
 

--- a/recipes-core/openjdk/openjdk-8_272.bb
+++ b/recipes-core/openjdk/openjdk-8_272.bb
@@ -14,6 +14,14 @@ do_install() {
     find ${D}${JDK_HOME} -name "*.debuginfo" -exec rm {} \;
 }
 
+do_package_qa_fix() {
+    # Fix QA Issue: File X in package openjdk-8-src contains reference to TMPDIR [buildpaths]
+    sed -i 's|${S}/||' "${B}/hotspot/linux_amd64_compiler2/generated/adfiles/dfa_x86_64.cpp"
+    sed -i 's|${S}/||' "${B}/hotspot/linux_amd64_compiler2/generated/adfiles/ad_x86_64.cpp"
+    sed -i 's|${S}/||' "${B}/hotspot/linux_amd64_compiler2/generated/adfiles/ad_x86_64.hpp"
+}
+addtask do_package_qa_fix after do_install before do_package
+
 PACKAGES:append = " \
     ${PN}-demo \
     ${PN}-source \

--- a/recipes-core/openjdk/openjre-8_272.bb
+++ b/recipes-core/openjdk/openjre-8_272.bb
@@ -10,7 +10,7 @@ do_install() {
     mkdir -p ${D}${JRE_HOME}
     cp -rp ${B}/images/j2re-image/* ${D}${JRE_HOME}
     chown -R root:root ${D}${JRE_HOME}
-    install -m644 ${WORKDIR}/jvm.cfg  ${D}${JRE_HOME}/lib/${JDK_ARCH}/
+    install -m644 ${UNPACKDIR}/jvm.cfg  ${D}${JRE_HOME}/lib/${JDK_ARCH}/
 }
 
 FILES:${PN}:append = "\

--- a/recipes-core/openjdk/patches-openjdk-7/build-hacks.patch
+++ b/recipes-core/openjdk/patches-openjdk-7/build-hacks.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Backport
+
 --- icedtea-2.6.1/Makefile.am.orig	2015-07-24 08:52:12.442036786 +0200
 +++ icedtea-2.6.1/Makefile.am	2015-07-24 08:58:25.046029702 +0200
 @@ -605,6 +605,12 @@

--- a/recipes-core/openjdk/patches-openjdk-7/fix_hotspot_crosscompile.patch
+++ b/recipes-core/openjdk/patches-openjdk-7/fix_hotspot_crosscompile.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Backport
+
 --- icedtea-2.6.1/acinclude.m4
 +++ icedtea-2.6.1/acinclude.m4
 @@ -906,6 +906,22 @@

--- a/recipes-core/openjdk/patches-openjdk-7/icedtea-crosscompile-fix.patch
+++ b/recipes-core/openjdk/patches-openjdk-7/icedtea-crosscompile-fix.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Backport
+
 diff --git openjdk/corba/make/common/shared/Platform.gmk openjdk/corba/make/common/shared/Platform.gmk
 index fb575fa..e0426ad 100644
 --- openjdk/corba/make/common/shared/Platform.gmk

--- a/recipes-core/openjdk/patches-openjdk-7/icedtea-hotspot-fix-string-literal-marcos.patch
+++ b/recipes-core/openjdk/patches-openjdk-7/icedtea-hotspot-fix-string-literal-marcos.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Backport
+
 --- openjdk/hotspot/src/share/vm/gc_implementation/g1/concurrentMark.cpp
 +++ openjdk/hotspot/src/share/vm/gc_implementation/g1/concurrentMark.cpp
 @@ -4378,9 +4378,9 @@

--- a/recipes-core/openjdk/patches-openjdk-7/icedtea-jdk-fix-xattr-include.patch
+++ b/recipes-core/openjdk/patches-openjdk-7/icedtea-jdk-fix-xattr-include.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Backport
+
 --- openjdk/jdk/src/solaris/native/sun/nio/fs/LinuxNativeDispatcher.c
 +++ openjdk/jdk/src/solaris/native/sun/nio/fs/LinuxNativeDispatcher.c
 @@ -38,7 +38,7 @@

--- a/recipes-core/openjdk/patches-openjdk-7/icedtea-jdk-nio-use-host-cc.patch
+++ b/recipes-core/openjdk/patches-openjdk-7/icedtea-jdk-nio-use-host-cc.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Backport
+
 --- openjdk/jdk/make/java/nio/Makefile
 +++ openjdk/jdk/make/java/nio/Makefile
 @@ -961,7 +961,7 @@

--- a/recipes-core/openjdk/patches-openjdk-7/icedtea-jdk-rmi-crosscompile.patch
+++ b/recipes-core/openjdk/patches-openjdk-7/icedtea-jdk-rmi-crosscompile.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Backport
+
 diff --git openjdk/jdk/make/com/sun/jmx/Makefile openjdk/jdk/make/com/sun/jmx/Makefile
 index eaf8a6e..4938613 100644
 --- openjdk/jdk/make/com/sun/jmx/Makefile

--- a/recipes-core/openjdk/patches-openjdk-7/icedtea-m4-fix-xattr-include-path.patch
+++ b/recipes-core/openjdk/patches-openjdk-7/icedtea-m4-fix-xattr-include-path.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Backport
+
 --- a/acinclude.m4
 +++ b/acinclude.m4
 @@ -2234,7 +2234,7 @@

--- a/recipes-core/openjdk/patches-openjdk-7/icedtea-xawt-crosscompile-fix.patch
+++ b/recipes-core/openjdk/patches-openjdk-7/icedtea-xawt-crosscompile-fix.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Backport
+
 --- openjdk/jdk/make/sun/xawt/Makefile
 +++ openjdk/jdk/make/sun/xawt/Makefile
 @@ -201,20 +201,6 @@

--- a/recipes-core/openjdk/patches-openjdk-7/icedtea-zero-hotspotfix.patch
+++ b/recipes-core/openjdk/patches-openjdk-7/icedtea-zero-hotspotfix.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Backport
+
 diff --git openjdk/hotspot/make/linux/makefiles/zeroshark.make openjdk/hotspot/make/linux/makefiles/zeroshark.make
 index c2a1484..156bdd0 100644
 --- openjdk/hotspot/make/linux/makefiles/zeroshark.make

--- a/recipes-core/openjdk/patches-openjdk-8/0003-build-fix-build-on-as-needed-toolchains-generic.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/0003-build-fix-build-on-as-needed-toolchains-generic.patch
@@ -64,6 +64,8 @@ place the $EXPECTED_OBJS early in the command line, before
 any additional libraries, so as to fix this once and for
 all.
 
+Upstream-Status: Backport
+
 Signed-off-by: André Draszik <andre.draszik@jci.com>
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
 

--- a/recipes-core/openjdk/patches-openjdk-8/0004-don-t-expect-fqpn-for-make.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/0004-don-t-expect-fqpn-for-make.patch
@@ -3,6 +3,8 @@ From: Jens Rehsack <rehsack@gmail.com>
 Date: Thu, 2 Jan 2020 13:42:43 +0100
 Subject: [PATCH] don't expect fqpn for make
 
+Upstream-Status: Backport
+
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
 
 ---

--- a/recipes-core/openjdk/patches-openjdk-8/0005-autoconf-filter-aclocal-copy-too.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/0005-autoconf-filter-aclocal-copy-too.patch
@@ -3,6 +3,8 @@ From: Jens Rehsack <rehsack@gmail.com>
 Date: Thu, 2 Jan 2020 13:44:25 +0100
 Subject: [PATCH] autoconf: filter aclocal copy too
 
+Upstream-Status: Backport
+
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
 
 ---

--- a/recipes-core/openjdk/patches-openjdk-8/0006-autoconf-handle-extra-output.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/0006-autoconf-handle-extra-output.patch
@@ -7,6 +7,8 @@ When adding the environment variable JAVA_TOOL_OPTIONS an extra line
 in the output from 'java -version' is produced. As this output is
 parsed by configure script the extra line has to be filtered out.
 
+Upstream-Status: Backport
+
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
 
 ---

--- a/recipes-core/openjdk/patches-openjdk-8/0008-autoconf-fix-shark-build-common.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/0008-autoconf-fix-shark-build-common.patch
@@ -3,6 +3,8 @@ From: Jens Rehsack <rehsack@gmail.com>
 Date: Thu, 2 Jan 2020 13:51:40 +0100
 Subject: [PATCH] autoconf: fix shark build (common)
 
+Upstream-Status: Backport
+
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
 
 ---

--- a/recipes-core/openjdk/patches-openjdk-8/0009-prevent-debuginfo-in-favour-of-openembedded-package-.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/0009-prevent-debuginfo-in-favour-of-openembedded-package-.patch
@@ -3,6 +3,8 @@ From: Jens Rehsack <rehsack@gmail.com>
 Date: Thu, 2 Jan 2020 13:53:50 +0100
 Subject: [PATCH] prevent debuginfo in favour of openembedded package split
 
+Upstream-Status: Backport
+
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
 
 ---

--- a/recipes-core/openjdk/patches-openjdk-8/0010-autoconf-remove-shell-variables-from-autoheader.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/0010-autoconf-remove-shell-variables-from-autoheader.patch
@@ -3,6 +3,8 @@ From: Jens Rehsack <rehsack@gmail.com>
 Date: Thu, 2 Jan 2020 13:55:29 +0100
 Subject: [PATCH] autoconf: remove shell variables from autoheader
 
+Upstream-Status: Backport
+
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
 
 ---

--- a/recipes-core/openjdk/patches-openjdk-8/0013-autoconf-remove-Werror.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/0013-autoconf-remove-Werror.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] autoconf: remove Werror
 We don't want to mess around with disabling warnings on new
 compiler versions therefore we remove Werror.
 
-Upstream-Status: Invalid
+Upstream-Status: Inappropriate [Yocto-specific fixes]
 
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
 

--- a/recipes-core/openjdk/patches-openjdk-8/1010-hotspot-fix-shark-build-common.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/1010-hotspot-fix-shark-build-common.patch
@@ -3,6 +3,8 @@ From: Jens Rehsack <rehsack@gmail.com>
 Date: Thu, 2 Jan 2020 10:22:19 +0100
 Subject: [PATCH 1010/1013] hotspot: fix shark build (common)
 
+Upstream-Status: Backport
+
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
 ---
  make/Makefile                               |  2 +-

--- a/recipes-core/openjdk/patches-openjdk-8/1011-hotspot-restrict-to-staging-dir.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/1011-hotspot-restrict-to-staging-dir.patch
@@ -3,6 +3,8 @@ From: Jens Rehsack <rehsack@gmail.com>
 Date: Thu, 2 Jan 2020 10:23:38 +0100
 Subject: [PATCH 1011/1013] hotspot: restrict to staging dir
 
+Upstream-Status: Backport
+
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
 ---
  make/linux/makefiles/dtrace.make | 2 +-

--- a/recipes-core/openjdk/patches-openjdk-8/2007-jdk-no-genx11-in-headless.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/2007-jdk-no-genx11-in-headless.patch
@@ -3,6 +3,8 @@ From: Jens Rehsack <rehsack@gmail.com>
 Date: Thu, 2 Jan 2020 13:25:12 +0100
 Subject: [PATCH] jdk: no genx11 in headless
 
+Upstream-Status: Backport
+
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
 
 ---

--- a/recipes-core/openjdk/patches-openjdk-8/2008-jdk-no-unused-deps.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/2008-jdk-no-unused-deps.patch
@@ -3,6 +3,8 @@ From: Jens Rehsack <rehsack@gmail.com>
 Date: Thu, 2 Jan 2020 13:26:42 +0100
 Subject: [PATCH] jdk: no unused deps
 
+Upstream-Status: Backport
+
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
 
 ---

--- a/recipes-core/rhino/rhino_1.7r4.bb
+++ b/recipes-core/rhino/rhino_1.7r4.bb
@@ -43,6 +43,6 @@ do_compile() {
 do_install:append() {
 	install -d ${D}${bindir}
 
-	install -m 0755 ${WORKDIR}/rhino ${D}${bindir}
-	install -m 0755 ${WORKDIR}/rhino-jsc ${D}${bindir}
+	install -m 0755 ${UNPACKDIR}/rhino ${D}${bindir}
+	install -m 0755 ${UNPACKDIR}/rhino-jsc ${D}${bindir}
 }

--- a/recipes-core/xalan-j/xalan-j_2.7.1.bb
+++ b/recipes-core/xalan-j/xalan-j_2.7.1.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Java XSLT processor"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = " \
-                    file://${WORKDIR}/bsf-2.4.0/LICENSE.txt;md5=b1e01b26bacfc2232046c90a330332b3 \
+                    file://${UNPACKDIR}/bsf-2.4.0/LICENSE.txt;md5=b1e01b26bacfc2232046c90a330332b3 \
                     file://${WORKDIR}/xalan-j_2_7_1/LICENSE.txt;md5=f4411652c74c374bb2564394185289ee \
                    "
 AUTHOR = "Apache Software Foundation"
@@ -31,7 +31,7 @@ do_compile() {
   mkdir -p build
 
   oe_makeclasspath cp -s xercesImpl regexp jlex cup bcel jaxp-1.3
-	scp="src:${WORKDIR}/bsf-2.4.0/src"
+	scp="src:${UNPACKDIR}/bsf-2.4.0/src"
 
   javac -J-Xmx512M -sourcepath $scp -cp $cp -d build `find src -name \*.java`
   (cd src && find org -name "*.properties" -exec cp {} ../build/{} \;)

--- a/recipes-core/xml-commons/dom4j-1.6.1/debian.patch
+++ b/recipes-core/xml-commons/dom4j-1.6.1/debian.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [dead project]
+
 --- dom4j-1.6.1+dfsg.orig/src/java/org/jaxen/dom4j/DocumentNavigator.java
 +++ dom4j-1.6.1+dfsg/src/java/org/jaxen/dom4j/DocumentNavigator.java
 @@ -0,0 +1,501 @@

--- a/recipes-core/xml-commons/xom-1.2.10/04_remove_sun_import.patch
+++ b/recipes-core/xml-commons/xom-1.2.10/04_remove_sun_import.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [dead project]
+
 diff -Nur xom-1.1/src15/nu/xom/JDK15XML1_0Parser.java xom-1.1.new/src15/nu/xom/JDK15XML1_0Parser.java
 --- xom-1.1/src15/nu/xom/JDK15XML1_0Parser.java	2004-08-17 19:18:30.000000000 +0530
 +++ xom-1.1.new/src15/nu/xom/JDK15XML1_0Parser.java	2007-11-13 15:25:08.000000000 +0530

--- a/recipes-extended/rxtx/files/kfreebsd_libpthread.patch
+++ b/recipes-extended/rxtx/files/kfreebsd_libpthread.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate
+
 Description: libc_r is not available, use libpthread
 Bug: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=585089
 Author: Scott Howard <showard@debian.org>

--- a/recipes-extended/rxtx/files/multiple_property_dirs.patch
+++ b/recipes-extended/rxtx/files/multiple_property_dirs.patch
@@ -2,6 +2,9 @@ Description: Handles the case when "java.ext.dirs" system property contains
  more than one directory.
 Author: Philip Ashmore <contact@philipashmore.com>
 Bug: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=646069
+
+Upstream-Status: Pending
+
 Index: rxtx/src/gnu/io/RXTXCommDriver.java
 ===================================================================
 --- rxtx.orig/src/gnu/io/RXTXCommDriver.java	2011-10-28 13:02:43.046717064 -0400

--- a/recipes-extended/rxtx/files/original_debian_changes.patch
+++ b/recipes-extended/rxtx/files/original_debian_changes.patch
@@ -1,6 +1,8 @@
 Description: Removes makefile install of RXTXcomm.jar, silences an unnecessary compiling error
 Origin: Mario Joussen <joussen@debian.org>, edited by Scott Howard <showard314@gmail.com> <2010-06-03>
 
+Upstream-Status: Pending
+
 Index: rxtx/src/RS485Imp.c
 ===================================================================
 --- rxtx.orig/src/RS485Imp.c	2011-10-31 02:58:18.280985274 -0400

--- a/recipes-extended/rxtx/files/port_to_hurd.patch
+++ b/recipes-extended/rxtx/files/port_to_hurd.patch
@@ -1,6 +1,8 @@
 Description: Defines __GNU__ to use the FHS
 Author: Scott Howard <showard@debian.org>
 
+Upstream-Status: Pending
+
 Index: rxtx/src/SerialImp.h
 ===================================================================
 --- rxtx.orig/src/SerialImp.h	2011-02-23 23:26:14.955993397 -0500

--- a/recipes-extended/rxtx/files/sys_io_h_check.patch
+++ b/recipes-extended/rxtx/files/sys_io_h_check.patch
@@ -2,6 +2,8 @@ Description: sys/io.h does not exist on all systems
 Bug: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=609152
 Author: Scott Howard <showard@debian.org>
 
+Upstream-Status: Pending
+
 Index: rxtx/configure.in
 ===================================================================
 --- rxtx.orig/configure.in	2011-02-23 23:01:09.596613286 -0500

--- a/recipes-extended/rxtx/files/ttyACM_port.patch
+++ b/recipes-extended/rxtx/files/ttyACM_port.patch
@@ -1,6 +1,8 @@
 Description: Allows for the enumeration of many additional ports, including ttyACM for Arduino Unos
 Author: Scott Howard <showard314@gmail.com>
 
+Upstream-Status: Pending
+
 Index: rxtx/src/gnu/io/RXTXCommDriver.java
 ===================================================================
 --- rxtx.orig/src/gnu/io/RXTXCommDriver.java	2010-10-04 23:14:47.236148507 -0400

--- a/recipes-extended/rxtx/files/uninstall_target.patch
+++ b/recipes-extended/rxtx/files/uninstall_target.patch
@@ -1,6 +1,9 @@
 Description: adds uninstall target to Makefile
 Author: Scott Howard <showard@debian.org>
 Bug: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=646069
+
+Upstream-Status: Pending
+
 Index: rxtx/Makefile.am
 ===================================================================
 --- rxtx.orig/Makefile.am	2011-10-31 02:43:21.532963961 -0400

--- a/recipes-extended/rxtx/files/zsystem_init_exception.patch
+++ b/recipes-extended/rxtx/files/zsystem_init_exception.patch
@@ -2,6 +2,8 @@ Description: print exception if initialization fails
 Bug: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=472053
 Author: Jan Niehusmann <jan@gondor.com>
 
+Upstream-Status: Pending
+
 Index: rxtx/src/gnu/io/RXTXPort.java
 ===================================================================
 --- rxtx.orig/src/gnu/io/RXTXPort.java	2011-02-03 20:48:21.824924891 -0500


### PR DESCRIPTION
Fixed no supported S = ${WORKDIR} in styhead.
Fixed missing Upstream-Status in patch QA issue in styhead.
Fix QA Issue: File X in package openjdk-8-src contains reference to TMPDIR [buildpaths]. ([issue](https://github.com/meta-java/meta-java/issues/38))
Fix QA Issue: Recipe LICENSE includes obsolete licenses GPLv2+ [obsolete-license].

Hi.

Without these fixes the layer won't build in Yokto 5.1.3 (kas 4.7).

P.S.: I'm going on vacation until March 11. I'll get in touch after that time.